### PR TITLE
add editorconfig and gitignore

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
- Added [editorconfig](http://editorconfig.org/) which makes contributing a lot easier. I use tabs as default and my text editor will now automatically pick up the correct settings for the project.
- Added `node_modules` to the `.gitignore` file to make sure it isn't pushed by accident
