### PR TITLE
use `esnext` linting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+'use strict';
 const url = require('url');
 const open = require('opener');
 const yargs = require('yargs');
@@ -29,7 +29,7 @@ yargs // eslint-disable-line no-unused-expressions
       default: 'Datex2 Linked'
     }
   },
-    function (argv) {
+    argv => {
       // FIXME: get port inside the baseuri
       let uri = url.parse(argv.base);
       uri.port = argv.port;

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,3 +1,4 @@
+'use strict';
 const http = require('http');
 const url = require('url');
 const path = require('path');
@@ -60,7 +61,7 @@ function serve(source, uri, title, silent) {
     });
 
     // serve the index
-    dispatcher.onGet('/', function (req, res) {
+    dispatcher.onGet('/', (req, res) => {
       const options = {};
       res.end(pug.renderFile(path.join(__dirname, '/../lib/index.pug'), {
         options,
@@ -69,10 +70,10 @@ function serve(source, uri, title, silent) {
     });
 
     // create a server
-    let server = http.createServer(handleRequest);
+    const server = http.createServer(handleRequest);
 
     // start the server
-    server.listen(uri.port, function () {
+    server.listen(uri.port, () => {
       resolve(`Server listening on: ${url.format(uri)}`);
     });
   });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bin": "lib/index.js"
   },
   "xo": {
-    "space": true
+    "space": true,
+    "esnext": true
   }
 }


### PR DESCRIPTION
Glad you picked XO, it has some really cool custom rules :).

Because you are targetting node >= 6, you can enable the `esnext` flag which will perform some extra checks.

Just close and forget if you don't want to be forced using fat-arrow functions, template literals, etc.
