### PR TITLE
don't use command in yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install `datex2-linker`
 
 ```sh
 $ npm install -g datex2-linker
-$ datex2-linker serve --source "http://www.verkeerscentrum.be/uitwisseling/datex2full" --base "http://localhost:8000/" --port 8000
+$ datex2-linker --source "http://www.verkeerscentrum.be/uitwisseling/datex2full" --base "http://localhost:8000/" --port 8000
 ```
 
 Then you should be able to find a data source in [`json-ld`](http://json-ld.org) at `/data.jsonld` and `/data.json`. At `/` there's some information about datex2, and other relevant links.

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,48 +5,48 @@ const open = require('opener');
 const yargs = require('yargs');
 const serve = require('./serve');
 
-yargs // eslint-disable-line no-unused-expressions
-  .usage('$0 <cmd> [args]')
+const argv = yargs // eslint-disable-line no-unused-expressions
+  .usage('$0')
   .boolean('silent')
+  .option('source', {
+    alias: 's',
+    describe: 'A valid datex2 feed'
+  })
+  .option('base', {
+    alias: 'b',
+    describe: 'baseuri for the created API'
+  })
+  .option('port', {
+    alias: 'p',
+    describe: 'port on which the API is served',
+    default: 80
+  })
+  .option('title', {
+    alias: 't',
+    describe: 'the title of the datafeed',
+    default: 'Datex2 Linked'
+  })
+  .demand('source', 'base')
   .describe('silent', 'runs without opening a browser and without output for every request')
-  .command('serve', 'serve up a JSON-LD API from a datex2 feed', {
-    source: {
-      alias: 's',
-      describe: 'A valid datex2 feed'
-    },
-    base: {
-      alias: 'b',
-      describe: 'baseuri for the created API'
-    },
-    port: {
-      alias: 'p',
-      describe: 'port on which the API is served',
-      default: 80
-    },
-    title: {
-      alias: 't',
-      describe: 'the title of the datafeed',
-      default: 'Datex2 Linked'
-    }
-  },
-    argv => {
-      // FIXME: get port inside the baseuri
-      let uri = url.parse(argv.base);
-      uri.port = argv.port;
-      // this is a hack because somehow url.format doesn't apply new changes.
-      uri = url.parse(uri.protocol + '//' + uri.hostname + ':' + uri.port);
-
-      // serve that datafeed and create accessible URIs
-      serve(argv.source, uri, argv.title, argv.silent).then(res => {
-        console.log(`The feed is now accessible on ${uri.href}\n ${res}`);
-        // open a browser to the index
-        if (!argv.silent) {
-          open(uri.href);
-        }
-      }).catch(err => {
-        console.error(`There was an error serving the provided datafeed:\n ${err}`);
-      });
-    })
   .help('help')
   .alias('h', 'help')
   .argv;
+
+// FIXME: get port inside the baseuri
+console.log('uri: ' + argv.base);
+let uri = url.parse(argv.base);
+uri.port = argv.port;
+// this is a hack because somehow url.format doesn't apply new changes.
+console.log('uri: ' + uri);
+uri = url.parse(uri.protocol + '//' + uri.hostname + ':' + uri.port);
+
+// serve that datafeed and create accessible URIs
+serve(argv.source, uri, argv.title, argv.silent).then(res => {
+  console.log(`The feed is now accessible on ${uri.href}\n ${res}`);
+  // open a browser to the index
+  if (!argv.silent) {
+    open(uri.href);
+  }
+}).catch(err => {
+  console.error(`There was an error serving the provided datafeed:\n ${err}`);
+});


### PR DESCRIPTION
this will make `datex2-linker` into the main command and add the options there

Fixes an issue where nothing worked since the version of yargs wasn't supplied
